### PR TITLE
Uncomment the color conversion

### DIFF
--- a/adviser/services/hci/video/VideoInput.py
+++ b/adviser/services/hci/video/VideoInput.py
@@ -61,8 +61,8 @@ class VideoInput(Service):
             ret, frame = self.cap.read()
             # Our operations on the frame come here
             if ret:
-                # rgb_img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                self.publish_img(rgb_img=frame)
+                rgb_img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                self.publish_img(rgb_img=rgb_img)
 
             end_time = datetime.datetime.now()
             time_diff = end_time - start_time


### PR DESCRIPTION
I don't know why this was uncommented in the master branch.
opencv returns BGR images, so it has to be converted to RGB.

For example, in `FeatureExtractor.py` thre is a code
```
frame = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
```
which assumes that the `video_input` topic publishes rgb images.